### PR TITLE
chore: update tsup configuration and package.json for module exports

### DIFF
--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -17,19 +17,16 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.cjs"
     },
     "./suigen": {
       "types": "./dist/suigen/index.d.ts",
       "import": "./dist/esm/suigen/index.js",
-      "require": "./dist/cjs/suigen/index.js"
+      "require": "./dist/cjs/suigen/index.cjs"
     }
   },
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -60,9 +57,5 @@
   "peerDependencies": {
     "typescript": "^5.8.3"
   },
-  "keywords": [
-    "sui",
-    "sdk",
-    "typescript"
-  ]
+  "keywords": ["sui", "sdk", "typescript"]
 }

--- a/ts-sdk/tsup.config.ts
+++ b/ts-sdk/tsup.config.ts
@@ -1,12 +1,37 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    'suigen/index': 'src/suigen/index.ts',
+export default defineConfig([
+  {
+    entry: {
+      index: 'src/index.ts',
+      'suigen/index': 'src/suigen/index.ts',
+    },
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    outDir: 'dist/esm',
+    splitting: false,
+    treeshake: true,
+    sourcemap: true,
+    minify: false,
+    shims: true,
+    platform: 'node',
+    target: 'node18',
   },
-  format: ['esm', 'cjs'],
-  dts: true,
-  clean: true,
-  outDir: 'dist',
-});
+  {
+    entry: {
+      index: 'src/index.ts',
+      'suigen/index': 'src/suigen/index.ts',
+    },
+    format: ['cjs'],
+    dts: false,
+    outDir: 'dist/cjs',
+    splitting: false,
+    treeshake: true,
+    sourcemap: true,
+    minify: false,
+    shims: true,
+    platform: 'node',
+    target: 'node18',
+  },
+]);


### PR DESCRIPTION
- Changed the file extensions in package.json for CommonJS exports from `.js` to `.cjs`.
- Refactored tsup.config.ts to define separate configurations for ESM and CJS formats, enhancing build clarity and modularity.
- Ensured that the output directories and settings are appropriately set for both module types.